### PR TITLE
fix: add motion-reduce utility variant to root layout html element

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="en" className="scroll-smooth motion-reduce:scroll-auto">
       <body
         className={`${inter.variable} ${poppins.variable} font-inter antialiased`}
       >


### PR DESCRIPTION
## Summary

Add the `motion-reduce:scroll-auto` class to the root layout `<html>` element. This ensures that users who prefer reduced motion see smooth scrolling disabled as expected.

## Changes

- Update `<html lang="en" className="scroll-smooth">` to `<html lang="en" className="scroll-smooth motion-reduce:scroll-auto">`

## Testing

- [x] Verified scroll behavior with `prefers-reduced-motion` enabled
- [x] Verified layout works normally when motion is not reduced

## Screenshots

N/A — no visible UI change
